### PR TITLE
changed rising/falling emojis

### DIFF
--- a/coinmarketticker.rb
+++ b/coinmarketticker.rb
@@ -58,7 +58,7 @@ class Coin
   end
 
   def to_s
-    "#{rising? ? '📈' : '📉'} #{symbol} $#{price_usd} (#{sign}#{percent_change}%)"
+    "#{rising? ? '🚀' : '⛷'} #{symbol} $#{price_usd} (#{sign}#{percent_change}%)"
   end
 
   def percent_change(period = DEFAULT_PERIOD)


### PR DESCRIPTION
### What?
Changed rising and falling emojis.
### Why?
I thought these looked more interesting and caught my eye better.
### How?
Changed rising emoji from 📈 to 🚀 and falling emoji from 📉 to ⛷.




<img width="198" alt="screen shot 2017-12-22 at 5 10 02 pm" src="https://user-images.githubusercontent.com/13720087/34313690-01bda1ac-e73b-11e7-84de-f1346485abf3.png">
<img width="201" alt="screen shot 2017-12-22 at 5 09 24 pm" src="https://user-images.githubusercontent.com/13720087/34313693-051f56ba-e73b-11e7-8532-aebc5a0c58ba.png">

cc: @Soleone 